### PR TITLE
fix: add display flex and inherit height

### DIFF
--- a/src/components/Container/styles.js
+++ b/src/components/Container/styles.js
@@ -25,6 +25,9 @@ export const Wrapper = styled.div`
     margin: 0 auto;
     padding: 8rem;
 
+    display: flex;
+    height: inherit;
+
     ${wrapperModifiers[modifier] && wrapperModifiers[modifier]()};
   `}
 `


### PR DESCRIPTION
Add display flex on wrapper because it's easy to control flex items
and add height's inheritance of his father